### PR TITLE
Staging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,6 +221,10 @@ GEM
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.25.1)
+      connection_pool
     regexp_parser (2.11.1)
     reline (0.6.2)
       io-console (~> 0.5)
@@ -286,6 +290,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.5, >= 7.1.5.1)
+  redis (~> 5.0)
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,10 +1,10 @@
 development:
   adapter: async
-
+  allow_same_origin_as_host: true
 test:
   adapter: test
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDIS_URL")
   channel_prefix: realtime_poc_production


### PR DESCRIPTION
Config environnement de dev action cable
ajout du allow_same_origin_as_host: true pour autoriser le front local
supression du fallback pour utiliser la variable définie par heroku